### PR TITLE
Allow wrapped ossec.conf file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,9 +34,13 @@ default['ossec']['agent_manager'] = value_for_platform_family(
   'default' => "#{node['ossec']['dir']}/contrib/ossec-batch-manager.pl"
 )
 
+# set the following attribute to true to manage ossec.conf via wrapper
+# this allows users to disable the Gyoku generated configuration feature implemented via:
+# https://github.com/yakara-ltd/ossec-cookbook/commit/b00b396306b59bf66e1eff50ea8d029179a8d15c
+default['ossec']['use_wrapped_ossec_conf'] = false
+
 # The following attributes are mapped to XML for ossec.conf using
 # Gyoku. See the README for details on how this works.
-
 default['ossec']['conf']['all']['syscheck']['frequency'] = 21_600
 default['ossec']['conf']['all']['rootcheck']['disabled'] = false
 default['ossec']['conf']['all']['rootcheck']['rootkit_files'] = "#{node['ossec']['dir']}/etc/shared/rootkit_files.txt"

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -43,6 +43,7 @@ chef_gem 'gyoku' do
   compile_time false if respond_to?(:compile_time)
 end
 
+# use default gyoku generated ossec.conf unless explicitly disabled
 file "#{node['ossec']['dir']}/etc/ossec.conf" do
   owner 'root'
   group 'ossec'
@@ -57,6 +58,8 @@ file "#{node['ossec']['dir']}/etc/ossec.conf" do
     conf = Chef::Mixin::DeepMerge.deep_merge(type_conf, all_conf)
     Chef::OSSEC::Helpers.ossec_to_xml('ossec_config' => conf)
   }
+
+  not_if node['ossec']['use_wrapped_ossec_conf'] == true
 end
 
 file "#{node['ossec']['dir']}/etc/shared/agent.conf" do
@@ -103,6 +106,7 @@ service 'ossec' do
 
   not_if do
     (node['ossec']['install_type'] != 'local' && !File.size?("#{node['ossec']['dir']}/etc/client.keys")) ||
-      (node['ossec']['install_type'] == 'agent' && node['ossec']['agent_server_ip'].nil?)
+      (node['ossec']['install_type'] == 'agent' && node['ossec']['agent_server_ip'].nil?) ||
+      (node['ossec']['use_wrapped_ossec_conf'] == true)
   end
 end


### PR DESCRIPTION
This feature adds an attribute that allows chefs using a wrapper cookbook
to disable the Gyoku driven hash_to_xml ossec.conf in favor of their own
file or template delivered solution.

Why did I do this? Unfortunately, the Gyoku solution doesn't (yet) support the
pretty-print option so the config file gets written as one single line of XML
which breaks the [Wazuh automated rule installation](http://bit.ly/2c6lQNr) that
I'm leveraging in my wrapper.
