### PR TITLE
GH-68: Derived Attribute Issue Preventing Proper Setting Of OSSEC Server IP

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,6 @@
 default['ossec']['dir']             = '/var/ossec'
 default['ossec']['server_role']     = 'ossec_server'
 default['ossec']['server_env']      = nil
-default['ossec']['agent_server_ip'] = nil
 
 # data bag configuration
 default['ossec']['data_bag']['encrypted']  = false
@@ -54,7 +53,7 @@ default['ossec']['conf']['all']['rootcheck']['rootkit_trojans'] = "#{node['ossec
 end
 
 default['ossec']['conf']['server']['remote']['connection'] = 'secure'
-default['ossec']['conf']['agent']['client']['server-ip'] = node['ossec']['agent_server_ip']
+default['ossec']['conf']['agent']['client']['server-ip'] = nil
 
 # agent.conf is also populated with Gyoku but in a slightly different
 # way. We leave this blank by default because Chef is better at

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,7 +30,7 @@ else
   end
 end
 
-node.set['ossec']['agent_server_ip'] = ossec_server.first
+node.default['ossec']['conf']['agent']['client']['server-ip'] = ossec_server.first
 
 include_recipe 'ossec::install_agent'
 

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -103,6 +103,6 @@ service 'ossec' do
 
   not_if do
     (node['ossec']['install_type'] != 'local' && !File.size?("#{node['ossec']['dir']}/etc/client.keys")) ||
-      (node['ossec']['install_type'] == 'agent' && node['ossec']['agent_server_ip'].nil?)
+      (node['ossec']['install_type'] == 'agent' && node['ossec']['conf']['agent']['client']['server-ip'].nil?)
   end
 end


### PR DESCRIPTION
Replace all references to `node['ossec']['agent_server_ip']` with `node['ossec']['conf']['agent']['client']['server-ip']` so as to avoid the derived attribute issue.  I acknowledge that this creates a breaking change for folks who rely on the old attribute so waiting for feedback before submitting this fix upstream. It appears to work for my purposes though.
