### PR TITLE
GH-69: Server Search Syntax Yields 400 Bad Request

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,7 +23,7 @@ ssh_hosts = []
 
 search_string = 'ossec:[* TO *]'
 search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
-search_string << " AND NOT role:#{node['ossec']['server_role']} AND NOT fqdn:#{node['fqdn']}"
+search_string << " AND NOT (role:#{node['ossec']['server_role']} OR fqdn:#{node['fqdn']})"
 
 search(:node, search_string) do |n|
   ssh_hosts << n['ipaddress'] if n['keys']


### PR DESCRIPTION
`AND NOT foo AND NOT bar` search logic fails; works when changed to `AND NOT (foo OR bar)`.
