### PR TITLE
GH-70: change ossec user to functional shell so scp works

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -34,6 +34,12 @@ node.set['ossec']['agent_server_ip'] = ossec_server.first
 
 include_recipe 'ossec::install_agent'
 
+# GH-70: update ossec user shell
+user 'ossec' do
+  action :modify
+  shell '/bin/bash'
+end
+
 dbag_name = node['ossec']['data_bag']['name']
 dbag_item = node['ossec']['data_bag']['ssh']
 ossec_key = if node['ossec']['data_bag']['encrypted']


### PR DESCRIPTION
- Need shell for scp. Package sets shell to `/bin/false`.
- Could alternatively use scponly shell, but no package for debian & don't want to add install and configuraiton of `rssh` shell.
- This should be fine as only permitting key based access.
