### PR TITLE
DEVOPS-190: replace data bags with chef-vault

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs and configures ossec'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.5'
 
-%w( apt yum-atomic ).each do |pkg|
+%w( apt chef-vault yum-atomic ).each do |pkg|
   depends pkg
 end
 

--- a/recipes/_ssh_key.rb
+++ b/recipes/_ssh_key.rb
@@ -54,4 +54,5 @@ execute 'update-selinux-config' do
     semanage fcontext -a -t ssh_home_t #{node['ossec']['dir']}/.ssh/authorized_keys && \
     restorecon -v '/var/ossec/.ssh/authorized_keys' \
   "
+  only_if "which sestatus && sestatus | grep status | grep enabled"
 end

--- a/recipes/_ssh_key.rb
+++ b/recipes/_ssh_key.rb
@@ -1,0 +1,47 @@
+#
+# Cookbook Name:: ossec
+# Recipe:: _ssh_key
+#
+# Copyright 2016 Strata Consulting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'chef-vault'
+
+ossec_key = chef_vault_item('ossec', 'ssh')
+
+# create .ssh directory
+directory "#{node['ossec']['dir']}/.ssh" do
+  owner 'ossec'
+  group 'ossec'
+  mode '0750'
+end
+
+# ossec clients authorized_keys file
+template "#{node['ossec']['dir']}/.ssh/authorized_keys" do
+  source 'ssh_key.erb'
+  owner 'ossec'
+  group 'ossec'
+  mode '0600'
+  variables(key: ossec_key['pubkey'])
+  only_if { node['ossec']['mode'] == 'client' }
+end
+
+template "#{node['ossec']['dir']}/.ssh/id_rsa" do
+  source 'ssh_key.erb'
+  owner 'root'
+  group 'ossec'
+  mode '0600'
+  variables(key: ossec_key['privkey'])
+  only_if { node['ossec']['mode'] == 'server' }
+end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+node.default['ossec']['mode'] = 'client'
 ossec_server = []
 
 search_string = "role:#{node['ossec']['server_role']}"
@@ -40,27 +41,8 @@ user 'ossec' do
   shell '/bin/bash'
 end
 
-dbag_name = node['ossec']['data_bag']['name']
-dbag_item = node['ossec']['data_bag']['ssh']
-ossec_key = if node['ossec']['data_bag']['encrypted']
-              Chef::EncryptedDataBagItem.load(dbag_name, dbag_item)
-            else
-              data_bag_item(dbag_name, dbag_item)
-            end
-
-directory "#{node['ossec']['dir']}/.ssh" do
-  owner 'ossec'
-  group 'ossec'
-  mode '0750'
-end
-
-template "#{node['ossec']['dir']}/.ssh/authorized_keys" do
-  source 'ssh_key.erb'
-  owner 'ossec'
-  group 'ossec'
-  mode '0600'
-  variables(key: ossec_key['pubkey'])
-end
+# setup passwordless ssh between ossec clients & servers
+include_recipe 'ossec::_ssh_key'
 
 file "#{node['ossec']['dir']}/etc/client.keys" do
   owner 'ossec'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+node.default['ossec']['mode'] = 'server'
+
 include_recipe 'ossec::install_server'
 
 ssh_hosts = []
@@ -43,27 +45,8 @@ template '/usr/local/bin/dist-ossec-keys.sh' do
   notifies :run, 'execute[dist-ossec-keys]'
 end
 
-dbag_name = node['ossec']['data_bag']['name']
-dbag_item = node['ossec']['data_bag']['ssh']
-ossec_key = if node['ossec']['data_bag']['encrypted']
-              Chef::EncryptedDataBagItem.load(dbag_name, dbag_item)
-            else
-              data_bag_item(dbag_name, dbag_item)
-            end
-
-directory "#{node['ossec']['dir']}/.ssh" do
-  owner 'root'
-  group 'ossec'
-  mode '0750'
-end
-
-template "#{node['ossec']['dir']}/.ssh/id_rsa" do
-  source 'ssh_key.erb'
-  owner 'root'
-  group 'ossec'
-  mode '0600'
-  variables(key: ossec_key['privkey'])
-end
+# setup passwordless ssh between ossec clients & servers
+include_recipe 'ossec::_ssh_key'
 
 include_recipe 'ossec::common'
 

--- a/spec/unit/recipes/_ssh_key_spec.rb
+++ b/spec/unit/recipes/_ssh_key_spec.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: ossec
+# Spec:: default
+#
+# Copyright 2016 Strata Consulting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require 'spec_helper'
+
+describe 'ossec::_ssh_key' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Prefer Chef-Vault model to [encrypted] data bags.

**NOTE**: I've not yet refactored unit tests to reflect this change. I'm wrapping this cookbook and using integration tests there to confirm the functionality of this change. Not the best, but I'm crunched for time.  Will get back to it after I get this deliverable met.

Opened GH-73 to see if there's appetite for this upstream.
