### PR TITLE
DEVOPS-192: Add Amazon Linux Support to Chef OSSEC Cookbook

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -19,7 +19,16 @@
 
 case node['platform_family']
 when 'fedora', 'rhel'
+  # default yum-atomic cookbook fails on amazon platform
+  if node[:platform] == 'amazon'
+    %w(atomic atomic-testing).each do |repo|
+      node.override['yum'][repo]['mirrorlist'] = "https://updates.atomicorp.com/channels/mirrorlist/#{repo}/centos-7-$basearch"
+      node.override['yum'][repo]['includepkgs'] = 'inotify-tools ossec-*'
+    end
+  end
+
   include_recipe 'yum-atomic'
+
 when 'debian'
   package 'lsb-release'
 

--- a/templates/default/dist-ossec-keys.sh.erb
+++ b/templates/default/dist-ossec-keys.sh.erb
@@ -5,6 +5,6 @@ for host in <%= @ssh_hosts.join(' ') %>
 do
   key=`mktemp`
   grep $host <%= node['ossec']['dir'] %>/etc/client.keys > $key
-  scp -i <%= node['ossec']['dir'] %>/.ssh/id_rsa -B -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossec@$host:<%= node['ossec']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
+  scp -o ConnectTimeout=5 -i <%= node['ossec']['dir'] %>/.ssh/id_rsa -B -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $key ossec@$host:<%= node['ossec']['dir'] %>/etc/client.keys >/dev/null 2>/dev/null
   rm $key
 done


### PR DESCRIPTION
Updated so yum-atomicorp cookbook works with Amazon Linux. Gated so that atomicorp repository is only used for OSSEC related packages given AtomiCorp's lack of official Amazon Linux support.

I've successfully tested this via `kitchen-nodes` provisioner in my wrapper cookbook:

``` ruby
$ kl
Instance             Driver   Provisioner  Verifier  Transport  Last Action
server-centos-72     Vagrant  Nodes        Inspec    Ssh        Verified
server-debian-711    Vagrant  Nodes        Inspec    Ssh        Verified
server-ubuntu-1404   Vagrant  Nodes        Inspec    Ssh        Verified
server-amazon-linux  Ec2      Nodes        Inspec    Ssh        Verified
client-centos-72     Vagrant  Nodes        Inspec    Ssh        Verified
client-debian-711    Vagrant  Nodes        Inspec    Ssh        Verified
client-ubuntu-1404   Vagrant  Nodes        Inspec    Ssh        Verified
client-amazon-linux  Ec2      Nodes        Inspec    Ssh        Verified
```
